### PR TITLE
Don't add group with no (valid) elements

### DIFF
--- a/svg/svg.py
+++ b/svg/svg.py
@@ -260,10 +260,12 @@ class Group(Transformable):
             item.matrix = self.matrix * item.matrix
             item.viewport = self.viewport
 
-            self.items.append(item)
             # Recursively append if elt is a <g> (group)
             if elt.tag == svg_ns + 'g':
                 item.append(elt)
+
+            if len(item.items) > 0:
+                self.items.append(item)
 
     def __repr__(self):
         return '<Group ' + self.id + '>: ' + repr(self.items)


### PR DESCRIPTION
From the commit message:

> Do the recursive step first. Then check if the child element has anything. It may be the case that the child element has no valid children, in which case don't both appending this group.

I ran into this problem after I tried running `svg_test.py` on a pdf generated from [pdf2svg](http://www.cityinthesky.co.uk/opensource/pdf2svg/). It created a bunch of tags like the following:

```
<g style="fill:rgb(0%,0%,0%);fill-opacity:1;">                                  
    <use xlink:href="#glyph1-8" x="554.6093" y="813.5435"/>                       
</g>
```

Although the invalid tag is successfully ignored in the recursive call to `append()` via the `elt_class` check, this isn't handled by the parent group. I think the only problem occurs when a group element only has invalid children, so hence the added check. I'm not familiar with how this might affect other code, but it doesn't seem to break anything else in the code.
