### PR TITLE
current point should be the start point of the path after a closepath command

### DIFF
--- a/svg/svg.py
+++ b/svg/svg.py
@@ -370,6 +370,7 @@ class Path(Transformable):
             # Close Path
                 l = Segment(current_pt, start_pt)
                 self.items.append(l)
+                current_pt = start_pt
 
 
             elif command in 'LHV':
@@ -677,4 +678,3 @@ for name, cls in inspect.getmembers(sys.modules[__name__], inspect.isclass):
     tag = getattr(cls, 'tag', None)
     if tag:
         svgClass[svg_ns + tag] = cls
-


### PR DESCRIPTION
This pull request fixes a bug in the `<path>` tag parser: after a "closepath" (`z`) command, the current point should become the start point of the path being closed according to the SVG specs:

> If a "closepath" is followed immediately by a "moveto", then the "moveto" identifies the start point of the next subpath. If a "closepath" is followed immediately by any other command, then the next subpath starts at the same initial point as the current subpath.

([source](https://www.w3.org/TR/SVG11/paths.html#PathDataClosePathCommand))

The bug manifests itself for paths consisting of multiple path segments (e.g, a letter "a" in certain SVG files when the letter is encoded as a single path such that the outer boundary is the first path segment and the boundary of the "hole" is the second path segment). In this case, when the start point of the second path is specified relative to the start point of the first path (i.e. with a `m` command immediately following the `z` command), the current code without the PR calculates the offset relative to the last point of the first path segment and not the first point.