### PR TITLE
Bugfix: current position not updated on 'Z' (close path) command

### DIFF
--- a/svg/svg.py
+++ b/svg/svg.py
@@ -370,6 +370,7 @@ class Path(Transformable):
             # Close Path
                 l = Segment(current_pt, start_pt)
                 self.items.append(l)
+                current_pt = start_pt
 
 
             elif command in 'LHV':


### PR DESCRIPTION
This caused wrong path interpretation if a 'Z' command was followed by a
relative movement.